### PR TITLE
Fix code scanning alert no. 2: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/insecure_hashing.py
+++ b/insecure_hashing.py
@@ -1,9 +1,10 @@
 # Use of insecure hash function MD5 (CodeQL vulnerability example)
-import hashlib
+from argon2 import PasswordHasher
 
 def store_password(password):
     # Vulnerable code: Using insecure hashing algorithm (MD5)
-    hashed_password = hashlib.md5(password.encode()).hexdigest()
-    print(f"Storing insecure hashed password: {hashed_password}")
+    ph = PasswordHasher()
+    hashed_password = ph.hash(password)
+    print(f"Storing secure hashed password: {hashed_password}")
 
 store_password("super_secure_password123")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 flask==2.2.5  # Outdated version, with known vulnerabilities
 requests==2.32.2  # Outdated version
+
+argon2-cffi==23.1.0


### PR DESCRIPTION
Fixes [https://github.com/fatma-gulfidan/SecurityDemo2/security/code-scanning/2](https://github.com/fatma-gulfidan/SecurityDemo2/security/code-scanning/2)

To fix the problem, we need to replace the use of the MD5 hashing algorithm with a stronger, more secure algorithm suitable for password hashing. One of the best options is to use the Argon2 algorithm, which is designed to be computationally expensive and includes a per-password salt by default. This can be achieved using the `argon2-cffi` library.

The changes required are:
1. Import the `PasswordHasher` class from the `argon2` library.
2. Replace the MD5 hashing code with Argon2 hashing.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
